### PR TITLE
Updates for PEAK

### DIFF
--- a/static/scripts/Code/main.cpp
+++ b/static/scripts/Code/main.cpp
@@ -10,7 +10,13 @@ struct moveResponse
     int wait_time;
 };
 
-enum gameEndResponse { win, draw, none };
+enum gameEndResponse
+{
+    gameEndResponseBlackWin,
+    gameEndResponseWhiteWin,
+    gameEndResponseDraw,
+    gameEndResponseIncomplete
+};
 
 extern "C" {
     
@@ -31,21 +37,36 @@ extern "C" {
         output.wait_time = (h.iterations == 0 ? 2500 : ((4000 * sqrt(h.iterations * h.gamma ) + 500)));
         b.write(m);
         b.add(m);
-        
-        /*
-         cout<<uint64totile(m.zet_id)<<endl<<uint64tobinstring(b.pieces[BLACK])<<endl<<uint64tobinstring(b.pieces[WHITE])<<endl;
-         if(is_win(b.pieces[player]))
-         cout<<"win"<<endl;
-         else if(b.is_full())
-         cout<<"draw"<<endl;
-         else cout<<"playing"<<endl;
-         */
-        
+
         output.index = uint64totile(m.zet_id);
         return output;
     }
     
-    int makemove (int seed, char* bp, char* wp, bool player) {
+    gameEndResponse evaluateGameEnd(char* bp, char* wp)
+    {
+        board b (binstringtouint64(bp), binstringtouint64(wp));
+        cout<<uint64tobinstring(b.pieces[BLACK])<<endl<<uint64tobinstring(b.pieces[WHITE])<<endl;
+        
+        if (is_win(b.pieces[BLACK]))
+        {
+            cout<<"win"<<endl;
+            return gameEndResponseBlackWin;
+        }
+        else if (is_win(b.pieces[WHITE]))
+        {
+            cout<<"win"<<endl;
+            return gameEndResponseWhiteWin;
+        }
+        else if(b.is_full())
+        {
+            cout<<"draw"<<endl;
+            return gameEndResponseDraw;
+        }
+        
+        return gameEndResponseIncomplete;
+    }
+    
+    int makemove(int seed, char* bp, char* wp, bool player) {
         return makemoveresponse(seed, bp, wp, player).index;
     }
 }

--- a/static/scripts/Code/main.cpp
+++ b/static/scripts/Code/main.cpp
@@ -4,29 +4,50 @@
 #include <ctime>
 using namespace std;
 
+struct moveResponse
+{
+    int index;
+    int wait_time;
+};
+
+enum gameEndResponse { win, draw, none };
+
 extern "C" {
-
-int makemove(int seed, char* bp, char* wp, bool player){
-  heuristic h;
-  zet m;
-  int wait_time;
-  mt19937_64 generator;
-  board b(binstringtouint64(bp),binstringtouint64(wp));
-  generator.seed(seed);
-  h.seed_generator(generator);
-  m=h.makemove_bfs(b,player);
-  cout<<bp<<"\t"<<wp<<endl;
-  wait_time=(h.iterations==0?2500:((4000*sqrt(h.iterations*h.gamma)+500)));
-  b.write(m);
-  b.add(m);
-
-  /*cout<<uint64totile(m.zet_id)<<endl<<uint64tobinstring(b.pieces[BLACK])<<endl<<uint64tobinstring(b.pieces[WHITE])<<endl;
-  if(is_win(b.pieces[player]))
-    cout<<"win"<<endl;
-  else if(b.is_full())
-    cout<<"draw"<<endl;
-  else cout<<"playing"<<endl;*/
-  return uint64totile(m.zet_id);
+    
+    moveResponse makemoveresponse(int seed, char* bp, char* wp, bool player) {
+        
+        moveResponse output;
+        heuristic h;
+        zet m;
+        mt19937_64 generator;
+        board b(binstringtouint64(bp),binstringtouint64(wp));
+        
+        generator.seed(seed);
+        h.seed_generator(generator);
+        m = h.makemove_bfs(b,player);
+        
+        cout<<bp<<"\t"<<wp<<endl;
+        
+        output.wait_time = (h.iterations == 0 ? 2500 : ((4000 * sqrt(h.iterations * h.gamma ) + 500)));
+        b.write(m);
+        b.add(m);
+        
+        /*
+         cout<<uint64totile(m.zet_id)<<endl<<uint64tobinstring(b.pieces[BLACK])<<endl<<uint64tobinstring(b.pieces[WHITE])<<endl;
+         if(is_win(b.pieces[player]))
+         cout<<"win"<<endl;
+         else if(b.is_full())
+         cout<<"draw"<<endl;
+         else cout<<"playing"<<endl;
+         */
+        
+        output.index = uint64totile(m.zet_id);
+        return output;
+    }
+    
+    int makemove (int seed, char* bp, char* wp, bool player) {
+        return makemoveresponse(seed, bp, wp, player).index;
+    }
 }
 
 }


### PR DESCRIPTION
Hi Bas,

This is Chris one of the iOS Developers at PEAK (we spoke over a video call a few weeks ago).  There were two small updates I needed to make.

The changes included in this pull request
1. **`wait_time` exposed in the `makemove()` output**
- This with a new `makemoveresponse()` method that exposes both the `wait_time` and the `index` generated.
- This does not break existing code, as `makemove()` still functions the same, it just filters the data from a `makemoveresponse()` call


2. **separate method created for evaluating game end**
- I need to evaluate the board after a human move, and it would be nicer if that action wasn't a consequence of requesting an AI move.
- The `evaluateGameEnd()` can be called with just the `bp` and `wp` strings, and returns an `enum`  to indicate which player has won, or whether it's a draw.
- This is a new method that has no impact on existing code (the `makemove()` will still return `36` when a win is detected, as normal.

Let me know what you think, and if you feel any modifications are necessary.

Kind Regards,
Chris,
iOS Dev, PEAK