### PR TITLE
Cleaned Up Warnings

### DIFF
--- a/static/scripts/Code/bfs.h
+++ b/static/scripts/Code/bfs.h
@@ -46,13 +46,29 @@ class node{
       Nchildren=0;
       m=0;
       if(b.black_has_won())
-        pess=opt=BLACK_WINS-depth,val=10000.0;
+      {
+          pess=opt=BLACK_WINS-depth;
+          val=10000.0;
+      }
       else
-      if(b.white_has_won())
-        pess=opt=WHITE_WINS+depth,val=-10000.0;
-      else if(b.is_full())
-        pess=opt=0,val=0.0;
-      else val=v,pess=WHITE_WINS+depth+1,opt=BLACK_WINS-depth-1;
+      {
+          if(b.white_has_won())
+          {
+              pess=opt=WHITE_WINS+depth;
+              val=-10000.0;
+          }
+          else if(b.is_full())
+          {
+              pess=opt=0;
+              val=0.0;
+          }
+          else
+          {
+              val=v;
+              pess=WHITE_WINS+depth+1;
+              opt=BLACK_WINS-depth-1;
+          }
+      }
     }
     ~node(){
       if(child){
@@ -64,7 +80,7 @@ class node{
       best=NULL;
     }
     void expand(vector<zet> candidate){
-      Nchildren=candidate.size();
+      Nchildren=(unsigned int)candidate.size();
       if(Nchildren>0){
         child=new node*[Nchildren];
         for(unsigned int i=0;i<Nchildren;i++){
@@ -156,7 +172,7 @@ class node{
     }
     zet bestmove(){
       double v;
-      uint64 m_best;
+      uint64 m_best=999;
       if(!best)
         return zet(0,val,player);
       if(determined()){
@@ -165,8 +181,13 @@ class node{
       }
       v=(player==BLACK?-20000.0:20000.0);
       for(unsigned int i=0;i<Nchildren;i++)
-        if((player==BLACK && child[i]->val>v)||(player==WHITE && child[i]->val<v))
-          v=child[i]->val,m_best=child[i]->m;
+      {
+          if((player==BLACK && child[i]->val>v)||(player==WHITE && child[i]->val<v))
+          {
+              v=child[i]->val;
+              m_best=child[i]->m;
+          }
+      }
       return zet(m_best,v,player);
     }
     bool stop(double thresh,bool talk=false){

--- a/static/scripts/Code/board.h
+++ b/static/scripts/Code/board.h
@@ -56,7 +56,7 @@ inline int num_bits(uint64 x){
     x = (x & m8 ) + ((x >>  8) & m8 ); //put count of each 16 bits into those 16 bits
     x = (x & m16) + ((x >> 16) & m16); //put count of each 32 bits into those 32 bits
     x = (x & m32) + ((x >> 32) & m32); //put count of each 64 bits into those 64 bits
-    return x;
+    return (int)x;
 }
 
 inline bool has_one_bit(uint64 x){

--- a/static/scripts/Code/features_all.cpp
+++ b/static/scripts/Code/features_all.cpp
@@ -7,11 +7,13 @@ Nfeatures(0), D0(6.0), K0(5.0), gamma(0.025), delta(0.2), lapse_rate(0.01), opp_
 	update();
 }
 #else
-heuristic::heuristic(): Nfeatures(731), stopping_thresh(10000.0), pruning_thresh(4.7651),
-gamma(0.001) ,lapse_rate(0.02768), opp_scale(1.0),center_weight(0.88889),
+heuristic::heuristic():
+center_weight(0.88889),
 w_act{0.90129,0.3,2.5,20,0.90129,0.3,2.5,20,0.90129,0.3,2.5,20,0.90129,0.3,2.5,20,0},
 w_pass{1.0515,0.35,2.9166,23.333,1.0515,0.35,2.9166,23.333,1.0515,0.35,2.9166,23.333,1.0515,0.35,2.9166,23.333,0},
 delta{0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1},
+Nfeatures(731),
+stopping_thresh(10000.0), pruning_thresh(4.7651), gamma(0.001), lapse_rate(0.02768), opp_scale(1.0),
 feature{{0x3ULL,0xcULL,2,w_act,w_pass,delta,0},
 {0x600ULL,0x1800ULL,2,w_act,w_pass,delta,0},
 {0xc0000ULL,0x300000ULL,2,w_act,w_pass,delta,0},

--- a/static/scripts/Code/heuristic.cpp
+++ b/static/scripts/Code/heuristic.cpp
@@ -124,10 +124,14 @@ void heuristic::get_features_from_file(char* filename){
 void heuristic::addfeature(uint64 config, int i){
   int shiftc=colmax(config);
   int shiftr=rowmax(config);
-  for(int col=0;col<shiftc;col++)
-    for(int row=0;row<shiftr;row++)
-      feature.push_back(pattern(shift(config,row,col),0,0,w_act,w_pass,delta,i));
-  Nfeatures=feature.size();
+  for (int col=0; col<shiftc; col++)
+  {
+      for(int row=0;row<shiftr;row++)
+      {
+          feature.push_back(pattern(shift(config,row,col),0,0,w_act,w_pass,delta,i));
+      }
+  }
+  Nfeatures = (unsigned int)feature.size();
 }
 
 void heuristic::addfeature(uint64 config, uint64 confempty, int i, int n){
@@ -136,11 +140,17 @@ void heuristic::addfeature(uint64 config, uint64 confempty, int i, int n){
   int rmin=rowmin(config,confempty,n);
   int rmax=rowmax(config,confempty,n);
   board b;
-  for(int col=cmin;col<cmax;col++)
-    for(int row=rmin;row<rmax;row++)
-      if(num_bits(shift(confempty,row,col))>=n)
-        feature.push_back(pattern(shift(config,row,col),shift(confempty,row,col),n,w_act,w_pass,delta,i));
-  Nfeatures=feature.size();
+  for (int col=cmin;col<cmax;col++)
+  {
+      for (int row=rmin; row<rmax; row++)
+      {
+          if(num_bits(shift(confempty,row,col))>=n)
+          {
+              feature.push_back(pattern(shift(config,row,col),shift(confempty,row,col),n,w_act,w_pass,delta,i));
+          }
+      }
+  }
+  Nfeatures = (unsigned int)feature.size();
 }
 
 void heuristic::update(){
@@ -269,12 +279,19 @@ vector<zet> heuristic::get_pruned_moves(board& b, bool player){
 
 zet heuristic::makerandommove(board bstart, bool player){
   vector<uint64> options;
-  int Noptions;
-  for(uint64 m=1;m!=boardend;m<<=1)
-    if(bstart.isempty(m))
-      options.push_back(m);
-  Noptions=options.size();
-  if(Noptions>0)
+  for(uint64 m=1; m!=boardend; m<<=1)
+  {
+      if(bstart.isempty(m))
+      {
+          options.push_back(m);
+      }
+  }
+    
+  int Noptions = (int)options.size();
+    
+  if(Noptions > 0)
+  {
     return zet(options[uniform_int_distribution<int>{0,Noptions-1}(engine)],0.0,player);
+  }
   return zet(0,0.0,player);
 }


### PR DESCRIPTION
Hi Bas, Chris from PEAK here again.

There are certain parts of your code that trigger C++ compiler warnings. The changes I've made are just to satisfy the C++ Gods, and will have no impact on the performance or compile time of the code. It will just make the console look good and empty when you run it.

I imagine these changes have very little impact on your end, but in the PEAK codebase: warnings trigger as compile time errors.

Please feel free to get back to me if you have any questions, or alternative suggestions.

Changes:
- Fixed `implicit conversion` by explicitly casting to `int` and `unsigned int` where necessary
- Fixed `possible misuse of comma` error, which appears to be an Xcode thing. In any case, if you have multiple arguments with a control loop, it's much better to use `{ braces }` and semicolons to avoid potential errors
- Fixed `opp_scale will be initialised after ....`. Properties in `C++` and `C` must be initialised in the same order they are declared in. This is in case a property is initialised using a different property, which could be uninitialised when needed if the ordering isn't correct.
- Fixed `m_best may be uninitialised when used`. Another Xcode warning. Fixed by initialising `m_best` with some junk data.